### PR TITLE
Tag untagged instances with default delete tag via config remediation

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -50,7 +50,7 @@ Resources:
             - !Ref TagValue
       AutomationTargetParameterName: InstanceId
 
-  RequireDeleteTag:
+  RequireManagedTag:
     Type: AWS::Config::ConfigRule
     Properties:
       ConfigRuleName: RequireDeleteTag

--- a/template.yaml
+++ b/template.yaml
@@ -64,7 +64,7 @@ Resources:
       InputParameters:
         tag1Key: !Ref TagName
 
-  TagUntagedInstances:
+  TagUntaggedInstances:
     Type: "AWS::Config::RemediationConfiguration"
     Properties:
       Automatic: true

--- a/template.yaml
+++ b/template.yaml
@@ -49,3 +49,75 @@ Resources:
           Values:
             - !Ref TagValue
       AutomationTargetParameterName: InstanceId
+
+  RequireDeleteTag:
+    Type: AWS::Config::ConfigRule
+    Properties:
+      ConfigRuleName: RequireDeleteTag
+      Description: !Sub "Checks whether the '${TagName}' tag is set for EC2 Instances."
+      Source:
+        Owner: AWS
+        SourceIdentifier: REQUIRED_TAGS
+      Scope:
+        ComplianceResourceTypes:
+          - AWS::EC2::Instance
+      InputParameters:
+        tag1Key: !Ref TagName
+
+  TagUntagedInstances:
+    Type: "AWS::Config::RemediationConfiguration"
+    Properties:
+      Automatic: true
+      ConfigRuleName: !Ref RequireDeleteTag
+      MaximumAutomaticAttempts: 5
+      RetryAttemptSeconds: 50
+      Parameters:
+        AutomationAssumeRole:
+          StaticValue:
+            Values:
+              - !GetAtt AutomationServiceRole.Arn
+        InstanceId:
+          ResourceValue:
+            Value: RESOURCE_ID
+      TargetId: !Ref TagInstancesDocument
+      TargetType: "SSM_DOCUMENT"
+
+  AutomationServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ssm.amazonaws.com
+                - ec2.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonSSMAutomationRole
+      Path: "/"
+      RoleName: AutomationServiceRole
+
+  TagInstancesDocument:
+    Type: AWS::SSM::Document
+    Properties:
+      DocumentType: Automation
+      Content:
+        schemaVersion: '0.3'
+        assumeRole: "{{ AutomationAssumeRole }}"
+        parameters:
+          InstanceId:
+            type: String
+          AutomationAssumeRole:
+            type: String
+        mainSteps:
+          - name: TagEC2Instance
+            action: aws:createTags
+            inputs:
+              ResourceType: EC2
+              ResourceIds:
+                - "{{ InstanceId }}"
+              Tags:
+                - Key: !Ref TagName
+                  Value: !Ref TagValue


### PR DESCRIPTION
/cc @Miradorn @sbstjn 

So könnte man das machen:
- Config rule, die Check ob der Tag `delete` gesetzt ist
- Auto remediation per SSM Automation, die den Tag mit default = `true` setzt